### PR TITLE
fix: Update totals display and calculations across invoice, purchase …

### DIFF
--- a/public/invoice/invoice.html
+++ b/public/invoice/invoice.html
@@ -600,22 +600,18 @@
                         <i class="fas fa-calculator text-blue-600 text-xl"></i>
                         <h2 class="text-xl font-semibold text-gray-800">Totals</h2>
                     </div>
-                    <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-4">
+                    <div class="grid grid-cols-1 md:grid-cols-3 gap-4">
                         <div class="bg-gray-50 p-4 rounded-lg">
-                            <span class="block text-sm font-medium text-gray-600 mb-1">Total Amount</span>
-                            <span class="text-gray-900 font-bold text-lg" id="view-total-amount">-</span>
+                            <span class="block text-sm font-medium text-gray-600 mb-1">Subtotal</span>
+                            <span class="text-gray-900 font-bold text-lg" id="view-subtotal">-</span>
                         </div>
                         <div class="bg-gray-50 p-4 rounded-lg">
-                            <span class="block text-sm font-medium text-gray-600 mb-1">Total Tax</span>
-                            <span class="text-gray-900 font-bold text-lg" id="view-total-tax">-</span>
+                            <span class="block text-sm font-medium text-gray-600 mb-1">Tax (GST)</span>
+                            <span class="text-gray-900 font-bold text-lg" id="view-tax">-</span>
                         </div>
-                        <div class="bg-blue-50 p-4 rounded-lg">
-                            <span class="block text-sm font-medium text-blue-600 mb-1">Grand Total with Tax</span>
-                            <span class="text-blue-900 font-bold text-lg" id="view-total-with-tax">-</span>
-                        </div>
-                        <div class="bg-green-50 p-4 rounded-lg">
-                            <span class="block text-sm font-medium text-green-600 mb-1">Grand Total Without Tax</span>
-                            <span class="text-green-900 font-bold text-lg" id="view-total-without-tax">-</span>
+                        <div class="bg-blue-50 p-4 rounded-lg border-2 border-blue-200">
+                            <span class="block text-sm font-medium text-blue-600 mb-1">Total Amount Due</span>
+                            <span class="text-blue-900 font-bold text-xl" id="view-grand-total">-</span>
                         </div>
                     </div>
                 </section>

--- a/public/invoice/invoice_view.js
+++ b/public/invoice/invoice_view.js
@@ -392,16 +392,23 @@ async function viewInvoice(invoiceId, userRole) {
         setTextContent('view-consignee-name', invoice.consignee_name);
         setTextContent('view-consignee-address', invoice.consignee_address);
         
+        // Set the totals for the view section (professional 3-box layout)
         if (userRole == 'admin' && type == 'original') {
-            setTextContent('view-total-amount', `₹ ${formatIndian(invoice.total_amount_original, 2)}`);
-            setTextContent('view-total-tax', `₹ ${formatIndian(invoice.total_tax_original, 2)}`);
-            setTextContent('view-total-with-tax', `₹ ${formatIndian(invoice.total_amount_original, 2)}`);
-            setTextContent('view-total-without-tax', `₹ ${formatIndian(invoice.total_amount_original - invoice.total_tax_original, 2)}`);
+            const subtotal = invoice.total_amount_original - invoice.total_tax_original;
+            const tax = invoice.total_tax_original;
+            const grandTotal = invoice.total_amount_original;
+            
+            setTextContent('view-subtotal', `₹ ${formatIndian(subtotal, 2)}`);
+            setTextContent('view-tax', tax > 0 ? `₹ ${formatIndian(tax, 2)}` : 'No Tax');
+            setTextContent('view-grand-total', `₹ ${formatIndian(grandTotal, 2)}`);
         } else {
-            setTextContent('view-total-amount', `₹ ${formatIndian(invoice.total_amount_duplicate, 2)}`);
-            setTextContent('view-total-tax', `₹ ${formatIndian(invoice.total_tax_duplicate, 2)}`);
-            setTextContent('view-total-with-tax', `₹ ${formatIndian(invoice.total_amount_duplicate, 2)}`);
-            setTextContent('view-total-without-tax', `₹ ${formatIndian(invoice.total_amount_duplicate - invoice.total_tax_duplicate, 2)}`);
+            const subtotal = invoice.total_amount_duplicate - invoice.total_tax_duplicate;
+            const tax = invoice.total_tax_duplicate;
+            const grandTotal = invoice.total_amount_duplicate;
+            
+            setTextContent('view-subtotal', `₹ ${formatIndian(subtotal, 2)}`);
+            setTextContent('view-tax', tax > 0 ? `₹ ${formatIndian(tax, 2)}` : 'No Tax');
+            setTextContent('view-grand-total', `₹ ${formatIndian(grandTotal, 2)}`);
         }
 
         // Payment History

--- a/public/purchaseOrder/purchaseOrder.html
+++ b/public/purchaseOrder/purchaseOrder.html
@@ -423,6 +423,28 @@
                     </div>
                 </section>
 
+                <!-- Totals Card -->
+                <section class="bg-white rounded-lg shadow-md p-6 border border-gray-200 fade-in">
+                    <div class="flex items-center gap-3 mb-4 pb-3 border-b border-gray-200">
+                        <i class="fas fa-calculator text-green-600 text-xl"></i>
+                        <h2 class="text-xl font-semibold text-gray-800">Totals</h2>
+                    </div>
+                    <div class="grid grid-cols-1 md:grid-cols-3 gap-4">
+                        <div class="bg-gray-50 p-4 rounded-lg">
+                            <span class="block text-sm font-medium text-gray-600 mb-1">Subtotal</span>
+                            <span class="text-gray-900 font-bold text-lg" id="view-subtotal">-</span>
+                        </div>
+                        <div class="bg-gray-50 p-4 rounded-lg">
+                            <span class="block text-sm font-medium text-gray-600 mb-1">Tax (GST)</span>
+                            <span class="text-gray-900 font-bold text-lg" id="view-tax">-</span>
+                        </div>
+                        <div class="bg-green-50 p-4 rounded-lg border-2 border-green-200">
+                            <span class="block text-sm font-medium text-green-600 mb-1">Total Amount Due</span>
+                            <span class="text-green-900 font-bold text-xl" id="view-grand-total">-</span>
+                        </div>
+                    </div>
+                </section>
+
                 <!-- Preview & Actions Card -->
                 <section class="bg-white rounded-lg shadow-md p-6 border border-gray-200 fade-in">
                     <div class="flex items-center gap-3 mb-4 pb-3 border-b border-gray-200">

--- a/public/purchaseOrder/purchaseOrder_view.js
+++ b/public/purchaseOrder/purchaseOrder_view.js
@@ -298,6 +298,28 @@ async function viewPurchaseOrder(purchaseOrderId) {
             viewItemsTableBody.appendChild(row);
         });
 
+        // Calculate and set totals (professional 3-box layout)
+        let subtotal = 0;
+        let totalTax = 0;
+        
+        (purchaseOrder.items || []).forEach(item => {
+            const qty = parseFloat(item.quantity || 0);
+            const unitPrice = parseFloat(item.unit_price || 0);
+            const rate = parseFloat(item.rate || 0);
+            const taxableValue = qty * unitPrice;
+            const cgst = (taxableValue * rate / 2) / 100;
+            const sgst = (taxableValue * rate / 2) / 100;
+            
+            subtotal += taxableValue;
+            totalTax += (cgst + sgst);
+        });
+        
+        const grandTotal = subtotal + totalTax;
+        
+        document.getElementById('view-subtotal').textContent = `₹ ${formatIndian(subtotal, 2)}`;
+        document.getElementById('view-tax').textContent = totalTax > 0 ? `₹ ${formatIndian(totalTax, 2)}` : 'No Tax';
+        document.getElementById('view-grand-total').textContent = `₹ ${formatIndian(grandTotal, 2)}`;
+
         // Generate the preview for print/PDF
         await generatePurchaseOrderViewPreview(purchaseOrder);
 

--- a/public/quotation/quotation.html
+++ b/public/quotation/quotation.html
@@ -485,25 +485,21 @@
                 <!-- Totals Card -->
                 <section class="bg-white rounded-lg shadow-md p-6 border border-gray-200 fade-in">
                     <div class="flex items-center gap-3 mb-4 pb-3 border-b border-gray-200">
-                        <i class="fas fa-calculator text-blue-600 text-xl"></i>
+                        <i class="fas fa-calculator text-purple-600 text-xl"></i>
                         <h2 class="text-xl font-semibold text-gray-800">Totals</h2>
                     </div>
-                    <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-4">
+                    <div class="grid grid-cols-1 md:grid-cols-3 gap-4">
                         <div class="bg-gray-50 p-4 rounded-lg">
-                            <span class="block text-sm font-medium text-gray-600 mb-1">Total Amount</span>
-                            <span class="text-gray-900 font-bold text-lg" id="view-total-amount">-</span>
+                            <span class="block text-sm font-medium text-gray-600 mb-1">Subtotal</span>
+                            <span class="text-gray-900 font-bold text-lg" id="view-subtotal">-</span>
                         </div>
                         <div class="bg-gray-50 p-4 rounded-lg">
-                            <span class="block text-sm font-medium text-gray-600 mb-1">Total Tax</span>
-                            <span class="text-gray-900 font-bold text-lg" id="view-total-tax">-</span>
+                            <span class="block text-sm font-medium text-gray-600 mb-1">Tax (GST)</span>
+                            <span class="text-gray-900 font-bold text-lg" id="view-tax">-</span>
                         </div>
-                        <div class="bg-blue-50 p-4 rounded-lg">
-                            <span class="block text-sm font-medium text-blue-600 mb-1">Grand Total with Tax</span>
-                            <span class="text-blue-900 font-bold text-lg" id="view-total-with-tax">-</span>
-                        </div>
-                        <div class="bg-green-50 p-4 rounded-lg">
-                            <span class="block text-sm font-medium text-green-600 mb-1">Grand Total Without Tax</span>
-                            <span class="text-green-900 font-bold text-lg" id="view-total-without-tax">-</span>
+                        <div class="bg-purple-50 p-4 rounded-lg border-2 border-purple-200">
+                            <span class="block text-sm font-medium text-purple-600 mb-1">Total Amount Due</span>
+                            <span class="text-purple-900 font-bold text-xl" id="view-grand-total">-</span>
                         </div>
                     </div>
                 </section>

--- a/public/quotation/quotation_view.js
+++ b/public/quotation/quotation_view.js
@@ -368,11 +368,14 @@ async function viewQuotation(quotationId, viewType) {
             itemNumber++;
         });
 
-        // Set totals
-        document.getElementById('view-total-amount').textContent = `₹ ${formatIndian(grandTotal, 2) || '-'}`;
-        document.getElementById('view-total-tax').textContent = viewType === 2 ? `₹ ${formatIndian(totalTax, 2) || '-'}` : 'No Tax';
-        document.getElementById('view-total-with-tax').textContent = viewType === 2 ? `₹ ${formatIndian(grandTotal, 2) || '-'}` : 'No Tax';
-        document.getElementById('view-total-without-tax').textContent = `₹ ${formatIndian(totalTaxable, 2) || '-'}`;
+        // Set totals (professional 3-box layout)
+        const subtotal = totalTaxable;
+        const tax = totalTax;
+        const total = grandTotal;
+        
+        document.getElementById('view-subtotal').textContent = `₹ ${formatIndian(subtotal, 2) || '-'}`;
+        document.getElementById('view-tax').textContent = viewType === 2 ? `₹ ${formatIndian(tax, 2) || '-'}` : 'No Tax';
+        document.getElementById('view-grand-total').textContent = `₹ ${formatIndian(total, 2) || '-'}`;
 
         // Update table header based on view type
         const tableHead = document.querySelector("#view-items-table thead tr");

--- a/public/waybill/wayBill.html
+++ b/public/waybill/wayBill.html
@@ -443,6 +443,28 @@
                     </div>
                 </div>
 
+                <!-- Totals Card -->
+                <div class="bg-white rounded-lg shadow-md p-6 border border-gray-200 fade-in">
+                    <div class="flex items-center gap-3 mb-4 pb-3 border-b border-gray-200">
+                        <i class="fas fa-calculator text-teal-600 text-xl"></i>
+                        <h2 class="text-xl font-semibold text-gray-800">Totals</h2>
+                    </div>
+                    <div class="grid grid-cols-1 md:grid-cols-3 gap-4">
+                        <div class="bg-gray-50 p-4 rounded-lg">
+                            <span class="block text-sm font-medium text-gray-600 mb-1">Subtotal</span>
+                            <span class="text-gray-900 font-bold text-lg" id="view-subtotal">-</span>
+                        </div>
+                        <div class="bg-gray-50 p-4 rounded-lg">
+                            <span class="block text-sm font-medium text-gray-600 mb-1">Tax (GST)</span>
+                            <span class="text-gray-900 font-bold text-lg" id="view-tax">-</span>
+                        </div>
+                        <div class="bg-teal-50 p-4 rounded-lg border-2 border-teal-200">
+                            <span class="block text-sm font-medium text-teal-600 mb-1">Total Amount Due</span>
+                            <span class="text-teal-900 font-bold text-xl" id="view-grand-total">-</span>
+                        </div>
+                    </div>
+                </div>
+
                 <!-- Preview & Actions Card -->
                 <div class="bg-white rounded-lg shadow-md p-6 border border-gray-200 fade-in">
                     <div class="flex items-center gap-3 mb-4 pb-3 border-b border-gray-200">

--- a/public/waybill/waybill_view.js
+++ b/public/waybill/waybill_view.js
@@ -158,6 +158,28 @@ async function viewWayBill(wayBillId) {
             viewItemsTableBody.appendChild(row);
         });
 
+        // Calculate and set totals (professional 3-box layout)
+        let subtotal = 0;
+        let totalTax = 0;
+        
+        (waybill.items || []).forEach(item => {
+            const qty = parseFloat(item.quantity || 0);
+            const unitPrice = parseFloat(item.unit_price || 0);
+            const rate = parseFloat(item.rate || 0);
+            const taxableValue = qty * unitPrice;
+            const cgst = (taxableValue * rate / 2) / 100;
+            const sgst = (taxableValue * rate / 2) / 100;
+            
+            subtotal += taxableValue;
+            totalTax += (cgst + sgst);
+        });
+        
+        const grandTotal = subtotal + totalTax;
+        
+        document.getElementById('view-subtotal').textContent = `₹ ${formatIndian(subtotal, 2)}`;
+        document.getElementById('view-tax').textContent = totalTax > 0 ? `₹ ${formatIndian(totalTax, 2)}` : 'No Tax';
+        document.getElementById('view-grand-total').textContent = `₹ ${formatIndian(grandTotal, 2)}`;
+
         generateViewPreviewHTML(waybill);
 
     } catch (error) {


### PR DESCRIPTION
This pull request refactors the totals display for invoices, quotations, purchase orders, and waybills, unifying them into a consistent, professional three-box layout showing Subtotal, Tax (GST), and Total Amount Due. The supporting JavaScript logic is updated to calculate and populate these new fields, replacing older, less clear field names and layouts. This change improves clarity and user experience across all document views.

**Totals UI refactor (HTML/CSS):**

* Updated the totals section in `invoice.html`, `quotation.html`, `purchaseOrder.html`, and `wayBill.html` to use a three-box layout: Subtotal, Tax (GST), and Total Amount Due, with color-coded styling for each document type. [[1]](diffhunk://#diff-233b5af38fef10f8ab128000cabd6037d55ab9de2799865d73baccc84f8edec8L603-R614) [[2]](diffhunk://#diff-488059b99319be6fc9b038e2331fc5c21d9264415bcfc82f9d1b09ea5d325e6aL488-R502) [[3]](diffhunk://#diff-71957ef00355dc00d829272630b401fb44ecfd42aeb0fe3d44399cd3159376d4R426-R447) [[4]](diffhunk://#diff-b3533b80228d799f90776fb281edef299303ef7de18b1aa477d6236f1519b017R446-R467)

**JavaScript logic updates:**

* Replaced previous totals logic in `invoice_view.js` to calculate and set subtotal, tax, and grand total for both admin and other user roles, matching the new layout.
* Refactored `quotation_view.js` to set the new subtotal, tax, and grand total fields, removing the older field assignments.
* Added logic in `purchaseOrder_view.js` and `waybill_view.js` to compute and set the subtotal, tax, and grand total based on item data, in line with the new UI. [[1]](diffhunk://#diff-4fee54736ddcba4ff29a73e984c4206d91bcba19051911b71664b6255b706348R301-R322) [[2]](diffhunk://#diff-cd434f73093fc89c20ccd87baf7134f5c7754e7e6a75238f5b9b7c91d34265bcR161-R182)

These changes ensure consistency and clarity in how totals are presented and calculated across all major document types.…order, quotation, and waybill views