### PR TITLE
v2.7.2 fix: Update quotation document styles for improved layout and readabi…

### DIFF
--- a/public/css/shared/documentStyles.css
+++ b/public/css/shared/documentStyles.css
@@ -168,7 +168,6 @@ body {
 .doc-quotation .title {
     background: #3765BC;
     padding: 12px 20px;
-    margin: 0 0 20px 0;
     text-align: center;
     font-size: 20px;
     color: #ffffff;
@@ -210,16 +209,16 @@ body {
     border-radius: 10px;
     margin-top: 10px;
     background: #ffffff;
-    table-layout: fixed;
+    table-layout: auto;
     overflow: hidden;
-    border: 0.1px solid #525252;
+    border: 1.5px solid #1b315a;
 }
 
 .doc-standard .fourth-section table th,
 .doc-standard .fourth-section table td,
 .doc-quotation table th,
 .doc-quotation table td {
-    border: 1px solid #000000;
+    border: 1.5px solid #1b315a;
     padding: 8px 6px;
     text-align: center;
     font-size: 12px;
@@ -237,7 +236,7 @@ body {
     text-transform: uppercase;
     letter-spacing: 0.3px;
     padding: 10px 6px;
-    border: 1px solid #000000;
+    border: 1.5px solid #1b315a;
 }
 
 .doc-standard .fourth-section table tbody tr:nth-child(even),
@@ -256,7 +255,6 @@ body {
 .doc-quotation .fifth-section {
     display: flex;
     justify-content: space-between;
-    margin-top: 25px;
     gap: 20px;
     page-break-inside: avoid;
 }
@@ -355,7 +353,6 @@ body {
 
 .doc-standard .fifth-section .bank-details-sub2 p,
 .doc-quotation .fifth-section .bank-details-sub2 p {
-    margin: 3px 0;
     color: #2d3748;
     font-size: 13px;
     line-height: 1.5;
@@ -373,7 +370,6 @@ body {
 .doc-standard .fifth-section-sub3,
 .doc-quotation .fifth-section-sub3 {
     display: flex;
-    margin-bottom: 12px;
     font-size: 14px;
     padding: 15px 18px;
     background: white;
@@ -397,7 +393,6 @@ body {
 .doc-standard .fifth-section .fifth-section-sub2 h3,
 .doc-quotation .fifth-section .fifth-section-sub2 h3 {
     font-size: 17px;
-    margin: 15px 0 10px 0;
     color: #1a1a1a;
     font-weight: 700;
     border-bottom: 3px solid #007bff;
@@ -604,15 +599,17 @@ body {
 }
 
 .doc-quotation table td:nth-child(1),
-.doc-quotation table td:nth-child(2),
-.doc-quotation table td:nth-child(3) { text-align: left; padding-left: 6px; }
+.doc-quotation table td:nth-child(2) { text-align: left; padding-left: 6px; }
+.doc-quotation table td:nth-child(3) { text-align: center; }
 .doc-quotation table td:first-child { text-align: center; font-weight: 600; }
+.doc-quotation table td:nth-child(5) { text-align: right; font-weight: 600; }
+.doc-quotation table td:nth-child(6) { text-align: right; font-weight: 600; }
+.doc-quotation table td:nth-child(8) { text-align: right; font-weight: 600; }
 
 .doc-quotation .terms-section,
 .doc-quotation .notes-section,
 .doc-quotation .closing-section {
     padding: 15px 18px;
-    margin: 20px 0;
 }
 
 .doc-quotation .terms-section { font-size: 13px; line-height: 1.7; }


### PR DESCRIPTION
This pull request updates the styling in `public/css/shared/documentStyles.css` to improve the appearance and consistency of quotation and standard document tables and sections. The main changes focus on table borders and layout, text alignment, and removal of unnecessary margins.

**Table styling and layout improvements:**

* Increased border thickness and changed border color for tables and table cells from `1px solid #000000` to `1.5px solid #1b315a`, and set `table-layout` to `auto` for better content handling. [[1]](diffhunk://#diff-e866e507c263d1d19ae7a0b4bfef9a8102cae04f7bfb82a6ccc00cb192f28bc6L213-R221) [[2]](diffhunk://#diff-e866e507c263d1d19ae7a0b4bfef9a8102cae04f7bfb82a6ccc00cb192f28bc6L240-R239)
* Adjusted text alignment and padding for specific columns in `.doc-quotation` tables to enhance readability and emphasis on key columns.

**Section margin and spacing adjustments:**

* Removed various margin settings from section headers and content blocks (e.g., `.doc-quotation .title`, `.doc-quotation .fifth-section`, `.doc-standard .fifth-section-sub3`, and heading elements) to create a more compact and uniform layout. [[1]](diffhunk://#diff-e866e507c263d1d19ae7a0b4bfef9a8102cae04f7bfb82a6ccc00cb192f28bc6L171) [[2]](diffhunk://#diff-e866e507c263d1d19ae7a0b4bfef9a8102cae04f7bfb82a6ccc00cb192f28bc6L259) [[3]](diffhunk://#diff-e866e507c263d1d19ae7a0b4bfef9a8102cae04f7bfb82a6ccc00cb192f28bc6L376) [[4]](diffhunk://#diff-e866e507c263d1d19ae7a0b4bfef9a8102cae04f7bfb82a6ccc00cb192f28bc6L400) [[5]](diffhunk://#diff-e866e507c263d1d19ae7a0b4bfef9a8102cae04f7bfb82a6ccc00cb192f28bc6L358)

These changes collectively help standardize the document appearance and improve the clarity of table data and section separation.