### PR TITLE
v2.7.5 fix: Enhance purchase order preview layout and branding for clarity a…

### DIFF
--- a/public/purchaseOrder/purchaseOrder_form.js
+++ b/public/purchaseOrder/purchaseOrder_form.js
@@ -429,17 +429,21 @@ function generatePreview() {
     totalAmount = grandTotal + roundOff;
 
     let totalsHTML = `
-        <div class="totals-section-sub1">
-            ${hasTax ? `
-            <p><strong>Taxable Value: </strong></p>
-            <p><strong>Total Tax: </strong></p>` : ""}
-            <p><strong>Grand Total: </strong></p>
-        </div>
-        <div class="totals-section-sub2">
-        ${hasTax ? `
-        <p>₹ ${formatIndian(totalTaxableValue, 2)}</p>
-        <p>₹ ${formatIndian(totalTax, 2)}</p>` : ""}
-        <p>₹ ${formatIndian(grandTotal + roundOff, 2)}</p>
+        <div style="display: flex; width: 100%;">
+            <div class="totals-section-sub1" style="width: 50%;">
+                ${hasTax ? `
+                <p>Taxable Value:</p>
+                <p>Total CGST:</p>
+                <p>Total SGST:</p>` : ""}
+                <p>Grand Total:</p>
+            </div>
+            <div class="totals-section-sub2" style="width: 50%;">
+                ${hasTax ? `
+                <p>₹ ${formatIndian(totalTaxableValue, 2)}</p>
+                <p>₹ ${formatIndian(totalCGST, 2)}</p>
+                <p>₹ ${formatIndian(totalSGST, 2)}</p>` : ""}
+                <p>₹ ${formatIndian(totalPrice, 2)}</p>
+            </div>
         </div>
     `;
 
@@ -478,19 +482,25 @@ function generatePreview() {
     const pagesHTML = itemPages.map((pageHTML, index) => {
         const isLastPage = index === itemPages.length - 1;
         return `
-    <div class="preview-container doc-standard">
-        <div class="first-section">
+    <div class="preview-container doc-standard doc-quotation">
+        <div class="header">
+        <div class="quotation-brand">
             <div class="logo">
-                <img src="../assets/logo.png"
-                    alt="Shresht Logo">
+                <img src="../assets/icon.png" alt="Shresht Logo">
             </div>
-            <div class="company-details">
+            <div class="quotation-brand-text">
                 <h1>SHRESHT SYSTEMS</h1>
-                <p>3-125-13, Harshitha, Onthibettu, Hiriadka, Udupi - 576113</p>
-                <p>Ph: 7204657707 / 9901730305 | GSTIN: 29AGCPN4093N1ZS</p>
-                <p>Email: shreshtsystems@gmail.com | Website: www.shreshtsystems.com</p>
+                <p class="quotation-tagline">CCTV & Security Solutions</p>
             </div>
         </div>
+        <div class="company-details">
+            <p>3-125-13, Harshitha, Onthibettu, Hiriadka, Udupi - 576113</p>
+            <p>Ph: 7204657707 / 9901730305</p>
+            <p>GSTIN: 29AGCPN4093N1ZS</p>
+            <p>Email: shreshtsystems@gmail.com</p>
+            <p>Website: www.shreshtsystems.com</p>
+        </div>
+    </div>
 
         <div class="second-section">
             <p>Purchase Order-${purchaseOrderId}</p>

--- a/public/purchaseOrder/purchaseOrder_view.js
+++ b/public/purchaseOrder/purchaseOrder_view.js
@@ -66,17 +66,21 @@ async function generatePurchaseOrderViewPreview(purchaseOrder) {
     });
 
     let totalsHTML = `
-        <div class="totals-section-sub1">
-            ${hasTax ? `
-            <p><strong>Taxable Value: </strong></p>
-            <p><strong>Total Tax: </strong></p>` : ""}
-            <p><strong>Grand Total: </strong></p>
-        </div>
-        <div class="totals-section-sub2">
-        ${hasTax ? `
-        <p>₹ ${formatIndian(totalTaxableValue, 2)}</p>
-        <p>₹ ${formatIndian(totalTax, 2)}</p>` : ""}
-        <p>₹ ${formatIndian(totalPrice, 2)}</p>
+        <div style="display: flex; width: 100%;">
+            <div class="totals-section-sub1" style="width: 50%;">
+                ${hasTax ? `
+                <p>Taxable Value:</p>
+                <p>Total CGST:</p>
+                <p>Total SGST:</p>` : ""}
+                <p>Grand Total:</p>
+            </div>
+            <div class="totals-section-sub2" style="width: 50%;">
+                ${hasTax ? `
+                <p>₹ ${formatIndian(totalTaxableValue, 2)}</p>
+                <p>₹ ${formatIndian(totalCGST, 2)}</p>
+                <p>₹ ${formatIndian(totalSGST, 2)}</p>` : ""}
+                <p>₹ ${formatIndian(totalPrice, 2)}</p>
+            </div>
         </div>
     `;
 
@@ -115,19 +119,25 @@ async function generatePurchaseOrderViewPreview(purchaseOrder) {
     const pagesHTML = itemPages.map((pageHTML, index) => {
         const isLastPage = index === itemPages.length - 1;
         return `
-    <div class="preview-container doc-standard doc-purchase-order">
-        <div class="first-section">
+    <div class="preview-container doc-standard doc-purchase-order doc-quotation">
+        <div class="header">
+        <div class="quotation-brand">
             <div class="logo">
-                <img src="../assets/logo.png"
-                    alt="Shresht Logo">
+                <img src="../assets/icon.png" alt="Shresht Logo">
             </div>
-            <div class="company-details">
+            <div class="quotation-brand-text">
                 <h1>SHRESHT SYSTEMS</h1>
-                <p>3-125-13, Harshitha, Onthibettu, Hiriadka, Udupi - 576113</p>
-                <p>Ph: 7204657707 / 9901730305 | GSTIN: 29AGCPN4093N1ZS</p>
-                <p>Email: shreshtsystems@gmail.com | Website: www.shreshtsystems.com</p>
+                <p class="quotation-tagline">CCTV & Security Solutions</p>
             </div>
         </div>
+        <div class="company-details">
+            <p>3-125-13, Harshitha, Onthibettu, Hiriadka, Udupi - 576113</p>
+            <p>Ph: 7204657707 / 9901730305</p>
+            <p>GSTIN: 29AGCPN4093N1ZS</p>
+            <p>Email: shreshtsystems@gmail.com</p>
+            <p>Website: www.shreshtsystems.com</p>
+        </div>
+    </div>
 
         <div class="second-section">
             <p>Purchase Order-${purchaseOrder.purchase_order_id || purchaseOrder.Id || ""}</p>


### PR DESCRIPTION
This pull request updates the purchase order and quotation preview layouts to improve clarity and consistency, especially regarding the display of tax breakdowns and company branding. The changes affect both the creation (`purchaseOrder_form.js`) and viewing (`purchaseOrder_view.js`) of purchase orders.

**Layout and Branding Improvements:**

* Updated the header section in both `generatePreview()` and `generatePurchaseOrderViewPreview()` to use a new branding layout, including a logo change from `logo.png` to `icon.png`, a new tagline, and clearer separation of company details. [[1]](diffhunk://#diff-525bfe1bfd5d669ccd20f778cae617bf9fcfb47a05d00aac74d1121da919bf35L481-R501) [[2]](diffhunk://#diff-4fee54736ddcba4ff29a73e984c4206d91bcba19051911b71664b6255b706348L118-R138)

**Tax and Totals Display Enhancements:**

* Modified the totals section to display CGST and SGST separately instead of just the total tax, and improved the layout using a two-column flexbox approach for better readability. [[1]](diffhunk://#diff-525bfe1bfd5d669ccd20f778cae617bf9fcfb47a05d00aac74d1121da919bf35L432-R446) [[2]](diffhunk://#diff-4fee54736ddcba4ff29a73e984c4206d91bcba19051911b71664b6255b706348L69-R84)stency