### PR TITLE
Fix/manager access

### DIFF
--- a/json/changelog.json
+++ b/json/changelog.json
@@ -1,6 +1,17 @@
 {
   "versions": [
     {
+      "version": "3.6.1",
+      "date": "2026-05-18",
+      "title": "Invoice View & Edit Fixes",
+      "changes": [
+        {
+          "type": "bugfix",
+          "description": "Invoice Edit: Fixed issue where edits to an invoice were not being saved correctly"
+        }
+      ]
+    },
+    {
       "version": "3.6.0",
       "date": "2026-01-09",
       "title": "Custom IDs & Module Overhauls",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "shresht-systems-management-system",
-  "version": "3.6.0",
+  "version": "3.6.1",
   "description": "Software for Shresht systems",
   "main": "main.js",
   "scripts": {

--- a/public/invoice/invoice.html
+++ b/public/invoice/invoice.html
@@ -471,25 +471,10 @@
         <div id="view">
             <div id="project-details-view" class="w-full max-w-6xl mx-auto px-4 space-y-6">
 
-                <!-- View Type Switcher - Segmented Control -->
+                <!-- View Type Switcher - Segmented Control (populated dynamically based on role) -->
                 <div class="flex justify-center fade-in">
                     <div id="view-type-tabs" class="inline-flex bg-gray-100 rounded-lg p-1 gap-1">
-                        <button type="button" data-view-type="duplicate"
-                            class="view-type-tab active px-4 py-2 rounded-md text-sm font-medium transition-all duration-200 bg-blue-600 text-white shadow-sm">
-                            Duplicate
-                        </button>
-                        <button type="button" data-view-type="duplicate-tax"
-                            class="view-type-tab px-4 py-2 rounded-md text-sm font-medium transition-all duration-200 text-gray-500">
-                            Duplicate + Tax
-                        </button>
-                        <button type="button" data-view-type="original"
-                            class="view-type-tab px-4 py-2 rounded-md text-sm font-medium transition-all duration-200 text-gray-500">
-                            Original
-                        </button>
-                        <button type="button" data-view-type="original-tax"
-                            class="view-type-tab px-4 py-2 rounded-md text-sm font-medium transition-all duration-200 text-gray-500">
-                            Original + Tax
-                        </button>
+                        <!-- Tabs are populated by invoice_view.js based on user role -->
                     </div>
                 </div>
 

--- a/public/invoice/invoice_home.js
+++ b/public/invoice/invoice_home.js
@@ -490,7 +490,8 @@ function createInvoiceCard(invoice) {
     if (editBtn) {
         editBtn.addEventListener('click', () => {
             sessionStorage.setItem('currentTab-status', 'update');
-            sessionStorage.setItem('update-invoice', 'duplicate');
+            const editType = editOriginalBtn ? 'duplicate' : 'original';
+            sessionStorage.setItem('update-invoice', editType);
             openInvoice(invoice.invoice_id);
         });
     }

--- a/public/invoice/invoice_view.js
+++ b/public/invoice/invoice_view.js
@@ -43,9 +43,47 @@ function updateInvoiceViewTypeTabs(activeViewType) {
 
 /**
  * Initialize view type tab click handlers
+ * Dynamically populates tabs based on user role:
  */
 function initInvoiceViewTypeTabs() {
-    const tabs = document.querySelectorAll('#view-type-tabs .view-type-tab');
+    const tabsContainer = document.getElementById('view-type-tabs');
+    if (!tabsContainer) return;
+
+    const userRole = sessionStorage.getItem('userRole');
+
+    // Define tabs based on role
+    let tabDefs;
+    if (userRole === 'admin') {
+        tabDefs = [
+            { viewType: 'duplicate', label: 'Duplicate' },
+            { viewType: 'duplicate-tax', label: 'Duplicate + Tax' },
+            { viewType: 'original', label: 'Original' },
+            { viewType: 'original-tax', label: 'Original + Tax' }
+        ];
+    } else {
+        // Manager and other roles
+        tabDefs = [
+            { viewType: 'original', label: 'Without Tax' },
+            { viewType: 'original-tax', label: 'With Tax' }
+        ];
+    }
+
+    // Set the default view type based on role
+    const defaultViewType = (userRole === 'admin') ? 'duplicate' : 'original';
+    currentInvoiceViewType = defaultViewType;
+
+    // Build tab buttons
+    tabsContainer.innerHTML = tabDefs.map(def => {
+        const isActive = def.viewType === defaultViewType;
+        const activeClasses = isActive ? 'active bg-blue-600 text-white shadow-sm' : 'text-gray-500';
+        return `<button type="button" data-view-type="${def.viewType}"
+            class="view-type-tab px-4 py-2 rounded-md text-sm font-medium transition-all duration-200 ${activeClasses}">
+            ${def.label}
+        </button>`;
+    }).join('');
+
+    // Attach click handlers
+    const tabs = tabsContainer.querySelectorAll('.view-type-tab');
     tabs.forEach(tab => {
         tab.addEventListener('click', async () => {
             const viewType = tab.dataset.viewType;
@@ -818,7 +856,12 @@ async function viewInvoice(invoiceId, userRole) {
             userRole = sessionStorage.getItem('userRole') || 'user';
         }
 
-        const type = sessionStorage.getItem('view-invoice') || 'duplicate';
+        // Determine default view type based on role
+        const userRoleForView = sessionStorage.getItem('userRole');
+        const defaultType = (userRoleForView === 'admin') ? 'duplicate' : 'original';
+        const type = (userRoleForView === 'admin')
+            ? (sessionStorage.getItem('view-invoice') || defaultType)
+            : defaultType; // Manager always views original
         const response = await fetch(`/invoice/${invoiceId}`);
         if (!response.ok) {
             throw new Error("Failed to fetch invoice");


### PR DESCRIPTION
This pull request updates the invoice view UI to dynamically adjust the available view type tabs and default behaviors based on the user's role (admin vs. manager/other). The main improvements focus on ensuring that admins have access to all invoice view types, while managers and other users see a simplified set of options. Additionally, the logic for determining the default and editable invoice view types has been refactored for clarity and correctness.

**Role-based view type selection and UI:**

* The tab buttons for switching invoice view types in `invoice.html` are now dynamically populated by `invoice_view.js` based on the user's role, instead of being hardcoded in the HTML.
* In `invoice_view.js`, the `initInvoiceViewTypeTabs` function now generates the appropriate tab options for admins (all four view types) and for managers/other roles (only "With Tax" and "Without Tax"). It also sets the default active tab based on the role.

**Default view type and editing logic:**

* The logic for determining which invoice view type to display by default is now role-aware: admins default to "duplicate" and managers/others to "original". Managers are always shown the "original" view, regardless of previous selections.
* When editing an invoice from the home page, the type of invoice to edit ("duplicate" or "original") is now determined based on the presence of the "edit original" button, ensuring the correct type is set in session storage.